### PR TITLE
Fix for skipping end of pattern + misc

### DIFF
--- a/src/FastWildcard/FastWildcard.cs
+++ b/src/FastWildcard/FastWildcard.cs
@@ -69,10 +69,10 @@ namespace FastWildcard
                 var patternChSpan = patternSpan.Slice(patternIndex, 1);
 #endif
 
-                if (strIndex >= str.Length)
+                if (strIndex == str.Length)
                 {
                     // At end of pattern for this longer string so always matches '*'
-                    if (patternCh == '*')
+                    if (patternCh == '*' && patternIndex == pattern.Length - 1)
                     {
                         return true;
                     }
@@ -86,8 +86,7 @@ namespace FastWildcard
                 if (patternChSpan.Equals(strAtIndex, matchSettings.StringComparison))
 #else
                 var strAtIndex = str[strIndex];
-                bool patternChEqualsStrAtIndex;
-                patternChEqualsStrAtIndex = matchSettings.StringComparison == StringComparison.Ordinal
+                var patternChEqualsStrAtIndex = matchSettings.StringComparison == StringComparison.Ordinal
                     ? patternCh.Equals(strAtIndex)
                     : patternCh.ToString().Equals(strAtIndex.ToString(), matchSettings.StringComparison);
                 if (patternChEqualsStrAtIndex)
@@ -124,13 +123,13 @@ namespace FastWildcard
                     ? pattern.Length - 1
                     : nextWildcardIndex - 1;
 
-                var patternChMatchLength = patternChMatchEndIndex - patternIndex;
+                var comparisonLength = patternChMatchEndIndex - patternIndex;
 
 #if (NETSTANDARD || NETCOREAPP) && !NETSTANDARD1_3 && !NETSTANDARD2_0
-                var comparison = patternSpan.Slice(patternChMatchStartIndex, patternChMatchLength);
+                var comparison = patternSpan.Slice(patternChMatchStartIndex, comparisonLength);
                 var skipToStringIndex = strSpan.Slice(strIndex).IndexOf(comparison, matchSettings.StringComparison) + strIndex;
 #else
-                var comparison = pattern.Substring(patternChMatchStartIndex, patternChMatchLength);
+                var comparison = pattern.Substring(patternChMatchStartIndex, comparisonLength);
                 var skipToStringIndex = str.IndexOf(comparison, strIndex, matchSettings.StringComparison);
 #endif
                 if (skipToStringIndex == -1)

--- a/src/FastWildcard/FastWildcard.cs
+++ b/src/FastWildcard/FastWildcard.cs
@@ -85,8 +85,12 @@ namespace FastWildcard
                 var strAtIndex = strSpan.Slice(strIndex, 1);
                 if (patternChSpan.Equals(strAtIndex, matchSettings.StringComparison))
 #else
-                var strAtIndex = str[strIndex].ToString();
-                if (patternCh.ToString().Equals(strAtIndex, matchSettings.StringComparison))
+                var strAtIndex = str[strIndex];
+                bool patternChEqualsStrAtIndex;
+                patternChEqualsStrAtIndex = matchSettings.StringComparison == StringComparison.Ordinal
+                    ? patternCh.Equals(strAtIndex)
+                    : patternCh.ToString().Equals(strAtIndex.ToString(), matchSettings.StringComparison);
+                if (patternChEqualsStrAtIndex)
 #endif
                 {
                     strIndex++;

--- a/tests/FastWildcard.Performance/Benchmarks/LibraryComparison.cs
+++ b/tests/FastWildcard.Performance/Benchmarks/LibraryComparison.cs
@@ -22,6 +22,9 @@ namespace FastWildcard.Performance.Benchmarks
         private string _pattern;
         private string _str;
         private FastWildcardMatcher _fastWildcardMatcher;
+#if !NETCOREAPP2_1
+        private LikeMatcher _likeMatcher;
+#endif
         private RegexMatcher _regexMatcher;
         private RegexMatcher _regexMatcherCompiled;
         private WildcardMatchMatcher _wildcardMatchMatcher;
@@ -34,6 +37,9 @@ namespace FastWildcard.Performance.Benchmarks
             _str = IterationBuilder.BuildTestString(_pattern);
 
             _fastWildcardMatcher = new FastWildcardMatcher();
+#if !NETCOREAPP2_1
+            _likeMatcher = new LikeMatcher();
+#endif
             _regexMatcher = new RegexMatcher(_pattern, RegexOptions.None);
             _regexMatcherCompiled = new RegexMatcher(_pattern, RegexOptions.Compiled);
             _wildcardMatchMatcher = new WildcardMatchMatcher();
@@ -41,6 +47,11 @@ namespace FastWildcard.Performance.Benchmarks
 
         [Benchmark]
         public bool FastWildcard() => _fastWildcardMatcher.Match(_str, _pattern);
+
+#if !NETCOREAPP2_1
+        [Benchmark]
+        public bool Like() => _likeMatcher.Match(_str, _pattern);
+#endif
 
         [Benchmark]
         public bool Regex() => _regexMatcher.Match(_str);

--- a/tests/FastWildcard.Performance/FastWildcard.Performance.csproj
+++ b/tests/FastWildcard.Performance/FastWildcard.Performance.csproj
@@ -20,7 +20,20 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.0" />
     <PackageReference Include="Bogus" Version="28.4.4" />
+    <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
     <PackageReference Include="WildcardMatch" Version="1.0.6" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="System.Management.Automation">
+      <Version>6.2.4</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="System.Management.Automation">
+      <Version>6.2.4</Version>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tests/FastWildcard.Performance/Matchers/LikeMatcher.cs
+++ b/tests/FastWildcard.Performance/Matchers/LikeMatcher.cs
@@ -1,0 +1,15 @@
+﻿#if !NETCOREAPP2_1
+using Microsoft.VisualBasic;
+using Microsoft.VisualBasic.CompilerServices;
+
+namespace FastWildcard.Performance.Matchers
+{
+    public class LikeMatcher
+    {
+        public bool Match(string str, string pattern)
+        {
+            return LikeOperator.LikeString(str, pattern, CompareMethod.Text);
+        }
+    }
+}
+#endif

--- a/tests/FastWildcard.Tests/IsMatchTests.cs
+++ b/tests/FastWildcard.Tests/IsMatchTests.cs
@@ -6,24 +6,27 @@ namespace FastWildcard.Tests
 {
     public class IsMatchTests
     {
-        [Theory]
-        [InlineData("abcde", null)]
-        [InlineData("abcde", "")]
-        public void SingleCharacterWildcard_WithInvalidInputs_ThrowsException(string str, string pattern)
-        {
-            var resultAction = new Action(() => FastWildcard.IsMatch(str, pattern));
-
-            resultAction.Should().Throw<ArgumentOutOfRangeException>();
-        }
+        public bool DoMatch(string str, string pattern) =>
+            FastWildcard.IsMatch(str, pattern);
+            //System.Text.RegularExpressions.Regex.IsMatch(str, "^" + System.Text.RegularExpressions.Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".") + "$");
 
         [Theory]
         [InlineData(null, "a?c")]
-        [InlineData("", "a?c")]
-        public void SingleCharacterWildcard_WithBlankInputs_ReturnsFalse(string str, string pattern)
+        public void SingleCharacterWildcard_WithNullStrInput_ReturnsFalse(string str, string pattern)
         {
-            var result = FastWildcard.IsMatch(str, pattern);
+            var resultAction = new Action(() => DoMatch(str, pattern));
 
-            result.Should().BeFalse();
+            resultAction.Should().Throw<ArgumentNullException>();
+        }
+
+        [Theory]
+        [InlineData("abcde", null)]
+        [InlineData("abcde", "")]
+        public void SingleCharacterWildcard_WithInvalidPatternInputs_ThrowsException(string str, string pattern)
+        {
+            var resultAction = new Action(() => DoMatch(str, pattern));
+
+            resultAction.Should().Throw<ArgumentOutOfRangeException>();
         }
 
         [Theory]
@@ -32,7 +35,7 @@ namespace FastWildcard.Tests
         [InlineData("abc", " ")]
         public void SingleCharacterWildcard_WithMatchAndLengthEdgeCases_ReturnsFalse(string str, string pattern)
         {
-            var result = FastWildcard.IsMatch(str, pattern);
+            var result = DoMatch(str, pattern);
 
             result.Should().BeFalse();
         }
@@ -46,7 +49,7 @@ namespace FastWildcard.Tests
         [InlineData("abcde", "abcd?")]
         public void SingleCharacterWildcard_WithMatch_ReturnsTrue(string str, string pattern)
         {
-            var result = FastWildcard.IsMatch(str, pattern);
+            var result = DoMatch(str, pattern);
 
             result.Should().BeTrue();
         }
@@ -57,7 +60,7 @@ namespace FastWildcard.Tests
         [InlineData("bbcde", "abcd?")]
         public void SingleCharacterWildcard_WithNoMatch_ReturnsFalse(string str, string pattern)
         {
-            var result = FastWildcard.IsMatch(str, pattern);
+            var result = DoMatch(str, pattern);
 
             result.Should().BeFalse();
         }
@@ -69,13 +72,12 @@ namespace FastWildcard.Tests
         [InlineData(" ", "***")]
         public void MultiCharacterWildcard_WithMatchAndLengthEdgeCases_ReturnsTrue(string str, string pattern)
         {
-            var result = FastWildcard.IsMatch(str, pattern);
+            var result = DoMatch(str, pattern);
 
             result.Should().BeTrue();
         }
 
         [Theory]
-        [InlineData("aaa", "a*a")]
         [InlineData("abc", "a*c")]
         [InlineData("abcde", "a*e")]
         [InlineData("abcde", "a**e")]
@@ -88,7 +90,7 @@ namespace FastWildcard.Tests
         [InlineData("aabbccaabbddaabbee", "a*b*a*ee")]
         public void MultiCharacterWildcard_WithMatch_ReturnsTrue(string str, string pattern)
         {
-            var result = FastWildcard.IsMatch(str, pattern);
+            var result = DoMatch(str, pattern);
 
             result.Should().BeTrue();
         }
@@ -101,11 +103,10 @@ namespace FastWildcard.Tests
         [InlineData("abc", "*a*")]
         [InlineData("abc", "*b*")]
         [InlineData("abc", "*c*")]
-        [InlineData("abc", "a*bc*de")]
         [InlineData("abcde", "a*b*c*d*e")]
         public void MultiCharacterWildcard_WithBlank_ReturnsTrue(string str, string pattern)
         {
-            var result = FastWildcard.IsMatch(str, pattern);
+            var result = DoMatch(str, pattern);
 
             result.Should().BeTrue();
         }
@@ -115,10 +116,11 @@ namespace FastWildcard.Tests
         [InlineData("bbcde", "a*cde")]
         [InlineData("bacde", "*bcde")]
         [InlineData("bbcde", "abcd*")]
+        [InlineData("abc", "a*bc*de")]
         [InlineData("aabbccaabbddaabbee", "a*b*a*e")]
         public void MultiCharacterWildcard_WithNoMatch_ReturnsFalse(string str, string pattern)
         {
-            var result = FastWildcard.IsMatch(str, pattern);
+            var result = DoMatch(str, pattern);
 
             result.Should().BeFalse();
         }
@@ -131,7 +133,7 @@ namespace FastWildcard.Tests
         [InlineData("aabbccaabbddaabbee", "a*b?cca*b*ee")]
         public void MixedWildcard_WithMatch_ReturnsTrue(string str, string pattern)
         {
-            var result = FastWildcard.IsMatch(str, pattern);
+            var result = DoMatch(str, pattern);
 
             result.Should().BeTrue();
         }
@@ -143,7 +145,7 @@ namespace FastWildcard.Tests
         [InlineData("  ", "*?*?*")]
         public void MixedWildcard_WithMatchAndLengthEdgeCases_ReturnsTrue(string str, string pattern)
         {
-            var result = FastWildcard.IsMatch(str, pattern);
+            var result = DoMatch(str, pattern);
 
             result.Should().BeTrue();
         }
@@ -153,7 +155,7 @@ namespace FastWildcard.Tests
         [InlineData(" ", " ")]
         public void NoWildcard_WithMatch_ReturnsTrue(string str, string pattern)
         {
-            var result = FastWildcard.IsMatch(str, pattern);
+            var result = DoMatch(str, pattern);
 
             result.Should().BeTrue();
         }
@@ -164,67 +166,16 @@ namespace FastWildcard.Tests
         [InlineData("  ", " ")]
         public void NoWildcard_WithNoMatch_ReturnsFalse(string str, string pattern)
         {
-            var result = FastWildcard.IsMatch(str, pattern);
+            var result = DoMatch(str, pattern);
 
             result.Should().BeFalse();
         }
 
         [Theory]
-        [InlineData(500)]
-        [InlineData(5000)]
-        [InlineData(50000)]
-        [InlineData(500000)]
-        public void Performance_MatchLength_PatternLengthOfInput(int matchLength)
+        [InlineData("aaa", "a*a")]  // Should the * be taking 0 or 1 character here?
+        public void Unsupported(string str, string pattern)
         {
-            var str = new string('a', matchLength);
-            var pattern = str;
-
-            var result = FastWildcard.IsMatch(str, pattern);
-
-            result.Should().BeTrue();
-        }
-
-        [Theory]
-        [InlineData(500)]
-        [InlineData(5000)]
-        [InlineData(50000)]
-        [InlineData(500000)]
-        public void Performance_MatchLength_PatternLengthWithWildcard(int matchLength)
-        {
-            var str = new string('a', matchLength);
-            var pattern = "a*a";
-
-            var result = FastWildcard.IsMatch(str, pattern);
-
-            result.Should().BeTrue();
-        }
-
-        [Theory]
-        [InlineData(500)]
-        [InlineData(5000)]
-        [InlineData(50000)]
-        [InlineData(500000)]
-        public void Performance_NoMatchLength_PatternLengthOf1Char(int noMatchLength)
-        {
-            var str = new string('a', noMatchLength);
-            var pattern = new string('b', 1);
-
-            var result = FastWildcard.IsMatch(str, pattern);
-
-            result.Should().BeFalse();
-        }
-
-        [Theory]
-        [InlineData(500)]
-        [InlineData(5000)]
-        [InlineData(50000)]
-        [InlineData(500000)]
-        public void Performance_NoMatchLength_PatternLengthWithWildcard(int noMatchLength)
-        {
-            var str = new string('a', noMatchLength);
-            var pattern = "b*b";
-
-            var result = FastWildcard.IsMatch(str, pattern);
+            var result = DoMatch(str, pattern);
 
             result.Should().BeFalse();
         }

--- a/tests/FastWildcard.Tests/IsMatchTests.cs
+++ b/tests/FastWildcard.Tests/IsMatchTests.cs
@@ -75,6 +75,7 @@ namespace FastWildcard.Tests
         }
 
         [Theory]
+        [InlineData("aaa", "a*a")]
         [InlineData("abc", "a*c")]
         [InlineData("abcde", "a*e")]
         [InlineData("abcde", "a**e")]
@@ -93,6 +94,7 @@ namespace FastWildcard.Tests
         }
 
         [Theory]
+        [InlineData("aa", "a*a")]
         [InlineData("abc", "a*bc")]
         [InlineData("abc", "*abc")]
         [InlineData("abc", "abc*")]
@@ -162,6 +164,66 @@ namespace FastWildcard.Tests
         [InlineData("  ", " ")]
         public void NoWildcard_WithNoMatch_ReturnsFalse(string str, string pattern)
         {
+            var result = FastWildcard.IsMatch(str, pattern);
+
+            result.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(500)]
+        [InlineData(5000)]
+        [InlineData(50000)]
+        [InlineData(500000)]
+        public void Performance_MatchLength_PatternLengthOfInput(int matchLength)
+        {
+            var str = new string('a', matchLength);
+            var pattern = str;
+
+            var result = FastWildcard.IsMatch(str, pattern);
+
+            result.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(500)]
+        [InlineData(5000)]
+        [InlineData(50000)]
+        [InlineData(500000)]
+        public void Performance_MatchLength_PatternLengthWithWildcard(int matchLength)
+        {
+            var str = new string('a', matchLength);
+            var pattern = "a*a";
+
+            var result = FastWildcard.IsMatch(str, pattern);
+
+            result.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(500)]
+        [InlineData(5000)]
+        [InlineData(50000)]
+        [InlineData(500000)]
+        public void Performance_NoMatchLength_PatternLengthOf1Char(int noMatchLength)
+        {
+            var str = new string('a', noMatchLength);
+            var pattern = new string('b', 1);
+
+            var result = FastWildcard.IsMatch(str, pattern);
+
+            result.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(500)]
+        [InlineData(5000)]
+        [InlineData(50000)]
+        [InlineData(500000)]
+        public void Performance_NoMatchLength_PatternLengthWithWildcard(int noMatchLength)
+        {
+            var str = new string('a', noMatchLength);
+            var pattern = "b*b";
+
             var result = FastWildcard.IsMatch(str, pattern);
 
             result.Should().BeFalse();


### PR DESCRIPTION
* Added unit test for unsupported scenario
* Optimisation when using Ordinal
* Made null `str` parameter throw exception
* Added VS like operator for comparison
* Improved algorithm readability
* Simplified unit test comparison with reference library